### PR TITLE
build: don't barf non-fatal configure output

### DIFF
--- a/configure
+++ b/configure
@@ -84,6 +84,13 @@ assert()
 
 generate()
 {
+	if [ "$1" -a \! -f "$2" -a \! -r "$2" ]; then
+		echo "Required file $2 does not exist or is not readable!" >&2
+		exit 1;
+	elif [ -z "$1" -a \( \! -f "$2" -o \! -r "$2" \) ]; then
+		return 0
+	fi
+
 	sed -e "s#@VERSION@#$VERSION#g"				\
 	    -e "s#@VERSION_MAJOR@#$VERSION_MAJOR#g"		\
 	    -e "s#@CC@#$CC#g"					\
@@ -104,7 +111,23 @@ generate()
 	    -e "s#@LDNAME@#$LDNAME#g"				\
 	    -e "s#@LDNAME_MAJOR@#$LDNAME_MAJOR#g"		\
 	    -e "s#@LDNAME_VERSION@#$LDNAME_VERSION#g"		\
-		$1 > $2
+		$2 > $3
+
+	ret=$?
+	if [ $ret \!= "0" ]; then
+		echo "Failed to build $3 from $2 (sed returned: $ret)!" >&2
+		exit $ret
+	fi
+}
+
+generate_required()
+{
+	generate "1" $1 $2
+}
+
+generate_optional()
+{
+	generate "" $1 $2
 }
 
 generate_stdout()
@@ -525,12 +548,14 @@ if test "$P_PWD" '!=' "$BUILD_DIR"; then
 	cp $BUILD_DIR/build/bcd.build $P_PWD/build/bcd.build &> /dev/null
 fi
 
-generate src/Makefile.in $P_PWD/src/Makefile
-generate regressions/Makefile.in $P_PWD/regressions/Makefile
-generate build/bcd.build.in $P_PWD/build/bcd.build
-generate build/regressions.build.in $P_PWD/build/regressions.build
-generate build/bcd.pc.in $P_PWD/build/bcd.pc
-generate Makefile.in $P_PWD/Makefile
+generate_required src/Makefile.in $P_PWD/src/Makefile
+generate_required regressions/Makefile.in $P_PWD/regressions/Makefile
+generate_required build/bcd.build.in $P_PWD/build/bcd.build
+generate_required build/bcd.pc.in $P_PWD/build/bcd.pc
+generate_required Makefile.in $P_PWD/Makefile
+
+generate_optional build/regressions.build.in $P_PWD/build/regressions.build
+
 touch src/*.c src/*/*.c
 rm -f $P_PWD/src/bcd-amalgamated.c
 echo "success"


### PR DESCRIPTION
regressions.build.in is not present in the source tree, but also does not seem to be essential. (Not knowing what should be in this file, and given that nothing seems to reference it, it's possible that perhaps the correct fix is to simply remove that line -- but this does make `generate` more robust either way.)

This patch introduces "optional" and "required" generator functions so that we can produce meaningful output when input files are not regular files, are unreadable, or if they do not exist. Alternatively, for non-essential input files that fit these criteria, we exit gracefully.

This patch also makes sure that sed returned without an error.