### PR TITLE
bcd: fix amalgamated build issues, const correctness

### DIFF
--- a/include/bcd.h
+++ b/include/bcd.h
@@ -25,6 +25,11 @@
 
 #if !defined(__linux__)
 #error "Unsupported platform."
+#else
+/* Needed for asprintf */
+# ifndef _GNU_SOURCE
+#  define _GNU_SOURCE
+# endif
 #endif /* __linux__ */
 
 #ifdef __cplusplus

--- a/include/internal/cf.h
+++ b/include/internal/cf.h
@@ -194,8 +194,10 @@ typedef struct bcd_config_v1 bcd_config_latest_version_t;
 /*
  * Initializes a bcd_config configuration struct based on the specified version.
  */
+#ifndef BCD_AMALGAMATED
 int bcd_config_init_internal(struct bcd_config *,
     unsigned int, bcd_error_t *);
+#endif
 
 /*
  * Assigns a versioned configuration to our internal configuration.

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -5,7 +5,11 @@ include @BUILD_DIR@/build/bcd.build
 TARGET_DIR=$(BUILD_DIR)/src
 SDIR=$(BUILD_DIR)/src
 INCLUDE_DIR=$(BUILD_DIR)/include
-HEADERS=$(INCLUDE_DIR)/*.h $(INCLUDE_DIR)/internal/*.h
+
+# bcd.h must come first as it contains necessary feature_test_macros(7) for linux
+HEADERS=$(INCLUDE_DIR)/bcd.h \
+	$(INCLUDE_DIR)/internal.h \
+	$(INCLUDE_DIR)/internal/*.h
 
 OBJECTS=bcd.o		\
 	cf.o		\

--- a/src/cf.c
+++ b/src/cf.c
@@ -80,9 +80,9 @@ int
 bcd_config_assign(const void *cf, struct bcd_error *e)
 {
 	/* All versions of bcd_config must start with unsigned int version. */
-	unsigned int version = *(unsigned int *)cf;
+	const struct bcd_config *bcd_cf = cf;
 
-	switch (version) {
+	switch (bcd_cf->version) {
 	case 1:
 		return bcd_config_assign_from_v1(cf, e);
 	default:

--- a/src/io.c
+++ b/src/io.c
@@ -19,7 +19,7 @@ static TAILQ_HEAD(, bcd_io_event) readyevents =
     TAILQ_HEAD_INITIALIZER(readyevents);
 
 struct bcd_io_listener {
-	const char *path;
+	char *path;
 	int fd;
 };
 
@@ -417,7 +417,7 @@ bcd_io_listener_unix(const char *path, int backlog, bcd_error_t *error)
 	return listener;
 
 error:
-	free((char *)listener->path);
+	free(listener->path);
 	free(listener);
 	return NULL;
 }


### PR DESCRIPTION
At least some distributions require _GNU_SOURCE to be set for stdio.h to
provide a prototype for asprintf(3). This introduces that definition and
reorders the Makefile.in (adding a comment) to ensure that macro is defined
before any includes are processed.

This also fixes various const-correctness issues found with -Wcast-qual
-Werror.