### PR TITLE
bcd: add bcd_associate_tid function

### DIFF
--- a/include/bcd.h
+++ b/include/bcd.h
@@ -252,6 +252,13 @@ void bcd_emit(const bcd_t *, volatile const char *);
  */
 void bcd_fatal(volatile const char *);
 
+/*
+ * Associate a new tid with this session. This is useful when attaching in a
+ * single thread at start-up and switching to some currently unknown thread at
+ * a later time (such as when it faults).
+ */
+int bcd_associate_tid(const bcd_t *, bcd_error_t *error, pid_t tid);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */


### PR DESCRIPTION
The API requires any thread that wishes to generate a trace to attach to the
socket. In systems with high thread counts, this can use many file
descriptors, while also adding additional latency to thread start time. This
new function allows changing the thread for a particular session, removing the
requirement for per-thread attaching (assuming structures are shared safely
between threads). This is expected to be useful in cases where threads may
be created and exit with frequency, and it is unknown which threads may be
trace candidates until they receive a signal.