### PR TITLE
bcd: add interface for passing arguments

### DIFF
--- a/include/bcd.h
+++ b/include/bcd.h
@@ -227,9 +227,15 @@ const char *bcd_error_message(const bcd_error_t *);
 int bcd_error_errno(const bcd_error_t *);
 
 /*
- * Make key-value association.
+ * Make key-value association. KV-pairs are LIFO-ordered.
  */
 int bcd_kv(bcd_t *, const char *, const char *, bcd_error_t *);
+
+/*
+ * Add an argument to the command line. Arguments are presented to the tracing
+ * process in order.
+ */
+int bcd_arg(bcd_t *, const char *, bcd_error_t *);
 
 /*
  * Generate a backtrace for calling thread, grouped by error message. This

--- a/src/bcd.c
+++ b/src/bcd.c
@@ -658,7 +658,7 @@ bcd_arg_set(struct bcd_session *session, struct bcd_packet *packet)
 				bcd_arg_length -= strlen(cursor->arg) + 1;
 				TAILQ_REMOVE(&bcd_arg_list, cursor, linkage);
 				free(cursor);
-				bcd_kv_count--;
+				bcd_arg_count--;
 				break;
 			}
 		}


### PR DESCRIPTION
Argument order is preserved to be the order of the calls to bcd_arg.
The utility of this is to be able to specify arbitrary arguments to the
tracing tool, as various arguments have utility outside of kv-pairs and
specifying a thread to trace.