### PR TITLE
Unlink the unix socket as soon as connection is accepted.

### DIFF
--- a/src/bcd.c
+++ b/src/bcd.c
@@ -41,6 +41,8 @@ struct bcd_pipe {
 };
 typedef struct bcd_pipe bcd_pipe_t;
 
+static int unlinked_path;
+
 enum bcd_op {
 	/*
 	 * Communicates configuration information through pipes, includes
@@ -234,7 +236,7 @@ static void
 bcd_child_exit(int e)
 {
 
-	unlink(bcd_config.ipc.us.path);
+	if(!unlinked_path) unlink(bcd_config.ipc.us.path);
 	_exit(e);
 }
 
@@ -344,6 +346,9 @@ bcd_handler_accept(bcd_io_event_t *client, unsigned int mask, void *closure)
 		bcd_io_event_destroy(client);
 	}
 
+  // Once we've accepted the client, we don't need the file anymore.
+  unlink(bcd_config.ipc.us.path);
+  unlinked_path = 1;
 	return;
 }
 

--- a/src/bcd.c
+++ b/src/bcd.c
@@ -346,9 +346,9 @@ bcd_handler_accept(bcd_io_event_t *client, unsigned int mask, void *closure)
 		bcd_io_event_destroy(client);
 	}
 
-  // Once we've accepted the client, we don't need the file anymore.
-  unlink(bcd_config.ipc.us.path);
-  unlinked_path = 1;
+	// Once we've accepted the client, we don't need the file anymore.
+	unlink(bcd_config.ipc.us.path);
+	unlinked_path = 1;
 	return;
 }
 


### PR DESCRIPTION
We have seen bcd filenames collide preventing initialization
of bcd. By unlinking as soon as soon as possible (as
opposed to only when the bcd child exits normally) the collision
is much less likely.

Hey folks,

I know this may not be the exact form that a change like this would take but I figured I'd start the discussion with a diff. I actually think using a socketpair is probably the best way to solve this problem, but there may be use cases or platforms I'm not considering where having a named file is necessary or unavoidable.