### PR TITLE
Fix compilation with glibc 2.30 and compiler warnings

### DIFF
--- a/src/bcd.c
+++ b/src/bcd.c
@@ -239,14 +239,14 @@ bcd_child_exit(int e)
 }
 
 #ifdef __linux__
-#ifndef gettid
+#if !defined(__GLIBC_PREREQ) || !__GLIBC_PREREQ(2, 30)
 static pid_t
 gettid(void)
 {
 
 	return syscall(__NR_gettid);
 }
-#endif /* !gettid */
+#endif /* !defined(__GLIBC_PREREQ) || !__GLIBC_PREREQ(2, 30) */
 #endif /* __linux__ */
 
 void

--- a/src/bcd.c
+++ b/src/bcd.c
@@ -249,6 +249,22 @@ gettid(void)
 #endif /* !defined(__GLIBC_PREREQ) || !__GLIBC_PREREQ(2, 30) */
 #endif /* __linux__ */
 
+#ifdef __linux__
+static size_t
+strlcpy(char *dst, const char *src, size_t n)
+{
+	size_t len = strlen(src);
+
+	if (n > 0) {
+		size_t copy = len < n ? len : (n - 1);
+		memmove(dst, src, copy);
+		dst[copy] = '\0';
+	}
+
+	return len;
+}
+#endif /* __linux__ */
+
 void
 bcd_error_handler_default(enum bcd_event event, pid_t pid, pid_t tid,
     const char *message)
@@ -1439,7 +1455,7 @@ bcd_child(void)
 	    bcd_handler_request_response,
 	    sizeof(struct bcd_session), &error) == -1)
 		goto fail;
-	strncpy(BCD_PACKET_PAYLOAD(&packet), bcd_config.ipc.us.path,
+	strlcpy(BCD_PACKET_PAYLOAD(&packet), bcd_config.ipc.us.path,
 	    BCD_SB_PATH);
 
 	r = bcd_sb_write(&pcb.sb.slave, BCD_OP_CF,
@@ -1570,7 +1586,7 @@ bcd_attach(struct bcd *bcd, bcd_error_t *error)
 	}
 
 	memset(&un, 0, sizeof un);
-	strncpy(un.sun_path, pcb.sb.path, sizeof un.sun_path);
+	strlcpy(un.sun_path, pcb.sb.path, sizeof un.sun_path);
 	un.sun_family = AF_UNIX;
 
 	for (;;) {
@@ -1745,7 +1761,7 @@ bcd_init(const struct bcd_config *cf, bcd_error_t *error)
 
 	switch (BCD_PACKET(&packet)->op) {
 	case BCD_OP_CF:
-		strncpy(sb->path, BCD_PACKET_PAYLOAD(&packet), BCD_SB_PATH);
+		strlcpy(sb->path, BCD_PACKET_PAYLOAD(&packet), BCD_SB_PATH);
 		break;
 	default:
 		bcd_error_set(error, 0, "failed to initialize path");

--- a/src/cf.c
+++ b/src/cf.c
@@ -12,6 +12,7 @@ bcd_config_init_v1(struct bcd_config_v1 *cf)
 {
 
 	cf->version = 1;
+	cf->flags = 0;
 	cf->oom_adjust = 1;
 	cf->handler = bcd_error_handler_default;
 	cf->timeout = 30;


### PR DESCRIPTION
This PR contains fixes for a couple problems I found:

The [glibc 2.30 release](https://sourceware.org/ml/libc-alpha/2019-08/msg00029.html) introduced `gettid` function which conflicts with the definition in BCD. I've updated the macro to check for glibc version to fix the detection:

```
/usr/lib64/ccache/cc -o broad broad.c /home/jvcelak/devel/bcd/src/bcd-amalgamated.c -Wall -O2 -pthread -ggdb -D_GNU_SOURCE -std=gnu99 -I/home/jvcelak/devel/bcd/include -lrt
/home/jvcelak/devel/bcd/src/bcd-amalgamated.c:910:1: error: static declaration of ‘gettid’ follows non-static declaration
  910 | gettid(void)
      | ^~~~~~
In file included from /usr/include/unistd.h:1170,
                 from /home/jvcelak/devel/bcd/src/bcd-amalgamated.c:679:
/usr/include/bits/unistd_ext.h:34:16: note: previous declaration of ‘gettid’ was here
   34 | extern __pid_t gettid (void) __THROW;
      |                ^~~~~~
```

GCC 9 warns about incorrect use of `strncpy` when copying paths. I've replaced the use with `strlcpy` which should be available on BSDs and I've provided a simple implementation for Linux:

```
/home/jvcelak/devel/bcd/src/bcd-amalgamated.c:2239:2: warning: ‘strncpy’ output may be truncated copying 108 bytes from a string of length 1023 [-Wstringop-truncation]
 2239 |  strncpy(un.sun_path, pcb.sb.path, sizeof un.sun_path);
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘bcd_child’,
    inlined from ‘bcd_os_fork’ at /home/jvcelak/devel/bcd/src/bcd-amalgamated.c:2179:3,
    inlined from ‘bcd_init’ at /home/jvcelak/devel/bcd/src/bcd-amalgamated.c:2395:10:
/home/jvcelak/devel/bcd/src/bcd-amalgamated.c:2108:2: warning: ‘strncpy’ specified bound 1024 equals destination size [-Wstringop-truncation]
 2108 |  strncpy(BCD_PACKET_PAYLOAD(&packet), bcd_config.ipc.us.path,
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 2109 |      BCD_SB_PATH);
      |      ~~~~~~~~~~~~
```

Also, a trivial fix for `flags` initialization within `bcd_config_v1` was included. This was noticed by clang-analyzer.

Feel free to tweak the changes to your likings. (I tested on Linux only.)