### PR TITLE
Don't allow the tracer or its subprocesses to inherit the pipe.

### DIFF
--- a/src/bcd.c
+++ b/src/bcd.c
@@ -1440,6 +1440,18 @@ bcd_child(void)
 	bcd_pipe_ensure_readonly(&pcb.sb.master);
 	bcd_pipe_ensure_writeonly(&pcb.sb.slave);
 
+	/*
+	 * The tracer may use additional subprocesses to do asynchronous processing
+	 * that doesn't need to prevent the tracee from exiting.  In the case of
+	 * bcd_fatal especially we rely on the monitor exiting to close the pipe to
+	 * signal the tracee to return from bcd_fatal.  The tracer itself doesn't need
+	 * this pipe, we wait on the tracer process before exiting the monitor.
+	 *
+	 * However, without setting CLOEXEC the tracer's subprocesses can keep the
+	 * pipe open, even if the tracer itself has exited.
+	 */
+	fcntl(pcb.sb.slave.fd[1], F_SETFD, FD_CLOEXEC);
+
 	listener = bcd_io_listener_unix(
 	    bcd_config.ipc.us.path, 128, &error);
 	if (listener == NULL)


### PR DESCRIPTION
bcd_fatal uses the pipe being closed to notify the tracee the monitor
process has exited, so if the tracer creates subprocesses that outlive
the monitor (the tracer itself will not as the monitor waits for it)
the tracee can stick along much longer than intended.