### PR TITLE
linux: use -1000 adjustment for /proc/<pid>/oom_score_adj first

### DIFF
--- a/src/os/linux.c
+++ b/src/os/linux.c
@@ -67,12 +67,12 @@ bcd_os_oom_adjust(bcd_error_t *error)
 {
 	char path[PATH_MAX];
 	pid_t pid = getpid();
-	const char *const score = "-17";
+	const char *score = "-1000";
 	size_t score_length = strlen(score);
 	ssize_t ac = 0;
 	int r, fd, i;
 
-	r = snprintf(path, sizeof(path), "/proc/%ju/oom_adj",
+	r = snprintf(path, sizeof(path), "/proc/%ju/oom_score_adj",
 	    (uintmax_t)pid);
 
 	for (i = 0;; i++) {
@@ -90,7 +90,8 @@ bcd_os_oom_adjust(bcd_error_t *error)
 			}
 
 			r = snprintf(path, sizeof(path),
-			    "/proc/%ju/oom_score_adj", (uintmax_t)pid);
+			    "/proc/%ju/oom_adj", (uintmax_t)pid);
+			score = "-17";
 			continue;
 		}
 


### PR DESCRIPTION
The intent of the `bcd_os_oom_adjust()` function is apparently to disable OOM killing of the process, as it writes the value -17 to the `/proc/<pid>/oom_adj` path if it exists.

Per the kernel documentation:

> For backwards compatibility with previous kernels, `/proc/<pid>/oom_adj` may also be used to tune the badness score.  Its acceptable values range from -16 (OOM_ADJUST_MIN) to +15 (OOM_ADJUST_MAX) and a special value of -17 (OOM_DISABLE) to disable oom killing entirely for that task.

If `/proc/<pid>/oom_adj` does not exist, `bcd_os_oom_adjust()` attempts to write the same value (-17) to `/proc/<pid>/oom_score_adj`. This results in different behavior, because this value is within the OOM score adjustment range. Per the kernel documentation:

> The value of `/proc/<pid>/oom_score_adj` is added to the badness score before it is used to determine which task to kill.  Acceptable values range from -1000 (OOM_SCORE_ADJ_MIN) to +1000 (OOM_SCORE_ADJ_MAX).  This allows userspace to polarize the preference for oom killing either by always preferring a certain task or completely disabling it.  The lowest possible value, -1000, is equivalent to disabling oom killing entirely for that task since it will always report a badness score of 0.

Additionally, the `bcd_os_oom_adjust()` function attempts to write to `/proc/<pid>/oom_adj` and, if that path does not exist, falls back to writing to `/proc/<pid>/oom_score_adj`. On modern kernels where both paths exist, this results in a kernel warning being logged:

https://github.com/torvalds/linux/blob/f69d02e37a85645aa90d18cacfff36dba370f797/fs/proc/base.c#L1074-L1080

This commit updates `bcd_os_oom_adjust()` to write "-1000" to `/proc/<pid>/oom_score_adj` first and, if that path does not exist, "-17" to the legacy `/proc/<pid>/oom_adj` path.