### PR TITLE
Don't rely on the implicit order of IO events.

### DIFF
--- a/src/bcd.c
+++ b/src/bcd.c
@@ -1325,7 +1325,15 @@ bcd_handler_fatal(bcd_io_event_t *client)
 		return;
 	}
 
-	bcd_backtrace_process(NULL);
+	/*
+	 * We may arrive here because our parent exited and bcd_handler_sb didn't run
+	 * yet. Only take a backtrace if our parent actually wrote a request to do
+	 * so.
+	 */
+	if (r > 0) {
+		bcd_backtrace_process(NULL);
+	}
+
 	bcd_child_exit(EXIT_SUCCESS);
 }
 


### PR DESCRIPTION
When a process potential tracee process exits all the ends of all the
pipes and sockets close, and the monitor process handles that in its
event loop.

The bcd_handler_sb handler exits the monitor on a hangup but we might
not handle that event before we handle the event of the end of the
pipe used for fatal hanging up.