### PR TITLE
Add support for abstract sockets on Linux.

### DIFF
--- a/include/bcd.h
+++ b/include/bcd.h
@@ -184,6 +184,8 @@ struct bcd_config {
 			/*
 			 * The path to the UNIX socket. If NULL, will evaluate
 			 * to /tmp/bcd.<pid>.
+			 *
+			 * On Linux, start the path with '@' to use an abstract socket.
 			 */
 			const char *path;
 		} us;

--- a/regressions/broad.c
+++ b/regressions/broad.c
@@ -56,7 +56,7 @@ request(pid_t tid)
 }
 
 int
-main(void)
+main(int argc, char **argv)
 {
 	bcd_t bcd;
 	bcd_error_t e;
@@ -74,6 +74,9 @@ main(void)
 	cf.invoke.output_file = "bcd_output_file";
 	cf.flags |= BCD_CONFIG_F_SETCOMM;
 	cf.request_handler = request;
+	if (argc > 1) {
+		cf.ipc.us.path = argv[1];
+	}
 
 	if (bcd_init(&cf, &e) == -1) {
 		fprintf(stderr, "error: failed to init: %s (%s)\n",


### PR DESCRIPTION
If the unix socket path is specified starting with a '@' use an
abstract unix(7) socket instead of one on the filesystem.

This is only supported on Linux. It is also backwards compatible
because previously socket paths were required to be absolute paths,
so code that configured a path that didn't start with '/' would not
have worked anyway.

https://www.man7.org/linux/man-pages/man7/unix.7.html