### PR TITLE
Optionally inherit the environment in the tracer.

### DIFF
--- a/include/bcd.h
+++ b/include/bcd.h
@@ -89,6 +89,8 @@ typedef void bcd_error_handler_t(enum bcd_event, pid_t, pid_t, const char *, int
 
 /* Set a unique command name for the monitor process. */
 #define BCD_CONFIG_F_SETCOMM (1UL << 0)
+/* Allow the tracer process to inherit the environment. */
+#define BCD_CONFIG_F_TRACERINHERITENV (1UL << 1)
 
 /*
  * First chance handler in BCD, invoked in the context of the BCD worker

--- a/src/bcd.c
+++ b/src/bcd.c
@@ -830,7 +830,11 @@ vfork_tracer(char **argv)
 
 	tracer_pid = vfork();
 	if (tracer_pid == 0) {
-		if (execve(bcd_config.invoke.path, argv, NULL) == -1)
+		char* const empty_env[] = {NULL};
+		char* const * envp = empty_env;
+		if (bcd_config.flags & BCD_CONFIG_F_TRACERINHERITENV)
+			envp = environ;
+		if (execve(bcd_config.invoke.path, argv, envp) == -1)
 			_exit(EXIT_FAILURE);
 	}
 


### PR DESCRIPTION
It can be desirable to configure custom tracer behavior with
environment variables, or tracers may have dependencies that are
discovered via LD_LIBRARY_PATH.