### PR TITLE
Don't deference session when it is NULL.

### DIFF
--- a/src/bcd.c
+++ b/src/bcd.c
@@ -971,7 +971,7 @@ static int
 bcd_request_handler(pid_t tid, struct bcd_session *session)
 {
 
-	if (tid == 0)
+	if (tid == 0 && session != NULL)
 		tid = session->tid;
 
 	if (bcd_config.request_handler != NULL &&


### PR DESCRIPTION
bcd_backtrace_process is called with a NULL session when the
tracee invokes bcd_fatal, and it in turn calls bcd_request_handler(0,
session).