### PR TITLE
If sigtimedwait times out, do not abort().

### DIFF
--- a/src/bcd.c
+++ b/src/bcd.c
@@ -928,8 +928,13 @@ bcd_execve(struct bcd_session *session, char **argv, size_t fr)
 		 */
 		if (signal_check(&sig) == 0) {
 			sig = sigtimedwait(&interestset, NULL, &timeout);
-			if (sig <= 0)
-				signal_check(&sig);
+			if (sig <= 0) {
+				int e = errno;
+				if (signal_check(&sig) == 0
+				  && (e == EINTR || e == EAGAIN)) {
+				  continue;
+				}
+			}
 		}
 
 		switch (sig) {


### PR DESCRIPTION
sigtimedwait is called here with a timeout of 1second. This means that
previously if the tracer didn't complete within a second the bcd monitor
process will call abort, as sig will be -1 and hit the default case.