### PR TITLE
Fix build with glibc 2.38 introducing strlcpy 

### DIFF
--- a/src/bcd.c
+++ b/src/bcd.c
@@ -348,6 +348,7 @@ gettid(void)
 #endif /* __linux__ */
 
 #ifdef __linux__
+#if !defined(__GLIBC_PREREQ) || !__GLIBC_PREREQ(2, 38)
 static size_t
 strlcpy(char *dst, const char *src, size_t n)
 {
@@ -361,6 +362,7 @@ strlcpy(char *dst, const char *src, size_t n)
 
 	return len;
 }
+#endif /* !defined(__GLIBC_PREREQ) || !__GLIBC_PREREQ(2, 38) */
 #endif /* __linux__ */
 
 void


### PR DESCRIPTION
The PR adds preprocessor macro to skip compilation of custom strlcpy code on glib 2.38 which added strlcpy.

The current build error on Fedora 39:

```
$ make
make -C src all
make[1]: Entering directory '/home/jan/devel/bcd/src'
/usr/bin/cc -ggdb -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -D_BSD_SOURCE -D_DEFAULT_SOURCE -std=gnu99 -Wall -W -Wundef -Wendif-labels -Wshadow -Wpointer-arith -Wcast-align -Wwrite-strings -Wstrict-prototypes -Wmissing-prototypes -Wnested-externs -Winline -Wdisabled-optimization -fstrict-aliasing -O2 -pipe -Wno-parentheses  -fPIC -I/home/jan/devel/bcd/include -c -o /home/jan/devel/bcd/src/bcd.o /home/jan/devel/bcd/src/bcd.c
/home/jan/devel/bcd/src/bcd.c:352:1: error: static declaration of ‘strlcpy’ follows non-static declaration
  352 | strlcpy(char *dst, const char *src, size_t n)
      | ^~~~~~~
In file included from /home/jan/devel/bcd/src/bcd.c:11:
/usr/include/string.h:506:15: note: previous declaration of ‘strlcpy’ with type ‘size_t(char * restrict,  const char * restrict,  size_t)’ {aka ‘long unsigned int(char * restrict,  const char * restrict,  long unsigned int)’}
  506 | extern size_t strlcpy (char *__restrict __dest,
      |               ^~~~~~~
make[1]: *** [Makefile:38: bcd.o] Error 1
make[1]: Leaving directory '/home/jan/devel/bcd/src'
make: *** [Makefile:6: all] Error 2
```