### PR TITLE
Avoid overflow on "score" read buffer when set to "-17".

### DIFF
--- a/src/os/linux.c
+++ b/src/os/linux.c
@@ -68,7 +68,6 @@ bcd_os_oom_adjust(bcd_error_t *error)
 	char path[PATH_MAX];
 	pid_t pid = getpid();
 	const char *score = "-1000";
-	size_t score_length = strlen(score);
 	ssize_t ac = 0;
 	int r, fd, i;
 
@@ -97,7 +96,7 @@ bcd_os_oom_adjust(bcd_error_t *error)
 
 		break;
 	}
-
+	const size_t score_length = strlen(score);
 	do {
 		ssize_t wr = write(fd, score, score_length);
 


### PR DESCRIPTION
Avoid overflow on "score" read buffer when set to "-17", when "write" is called. Introduced in https://github.com/backtrace-labs/bcd/commit/e5740aa4706c262cae6ebdd04dba3a71c6094cc8 from https://github.com/backtrace-labs/bcd/pull/15