### PR TITLE
Adding ARM support

### DIFF
--- a/include/internal/cc.h
+++ b/include/internal/cc.h
@@ -8,7 +8,12 @@
 #define BCD_MD_PAGESIZE	4096ULL
 #define BCD_SECTION "BACKTRACE_BCD_SB"
 
+#ifdef __aarch64__
+#define BCD_CC_FORCE(M, R)	\
+	__asm__ __volatile__("" : "=m" (M) : "r" (*(R)) : "memory");
+#else
 #define BCD_CC_FORCE(M, R)	\
 	__asm__ __volatile__("" : "=m" (M) : "q" (*(R)) : "memory");
+#endif
 
 #endif /* BCD_INTERNAL_CC_H */

--- a/include/internal/cc.h
+++ b/include/internal/cc.h
@@ -8,12 +8,7 @@
 #define BCD_MD_PAGESIZE	4096ULL
 #define BCD_SECTION "BACKTRACE_BCD_SB"
 
-#ifdef __aarch64__
 #define BCD_CC_FORCE(M, R)	\
 	__asm__ __volatile__("" : "=m" (M) : "r" (*(R)) : "memory");
-#else
-#define BCD_CC_FORCE(M, R)	\
-	__asm__ __volatile__("" : "=m" (M) : "q" (*(R)) : "memory");
-#endif
 
 #endif /* BCD_INTERNAL_CC_H */


### PR DESCRIPTION
Currently, any attempt to build this on an ARM (aarch64) machine will fail because of an "asm volatile" memory fence that has an x86 specific integer register constraint.  I admittedly don't fully understand why this is necessary, so I #ifdef'd it out on ARM to use a general register constraint.  This seems to work nicely, and should be directly equivalent:

https://developer.arm.com/documentation/dui0774/l/armclang-Inline-Assembler/Inline-assembly-constraint-strings/Constraint-codes-for-AArch64-state?lang=en 
https://gcc.gnu.org/onlinedocs/gcc-14.3.0/gcc/Simple-Constraints.html 
https://gcc.gnu.org/onlinedocs/gcc-14.3.0/gcc/Machine-Constraints.html