### PR TITLE
initialize default_config to supress compiler warning

### DIFF
--- a/src/bcd.c
+++ b/src/bcd.c
@@ -1882,7 +1882,7 @@ bcd_init(const struct bcd_config *cf, bcd_error_t *error)
 	time_t timeout_abstime;
 
 	if (cf == NULL) {
-		bcd_config_latest_version_t default_config;
+		bcd_config_latest_version_t default_config = {0};
 		bcd_error_t noerror;
 
 		ret = bcd_config_init_internal(


### PR DESCRIPTION
Amalgamated build of bcd yields a new warning on Fedora 43 with GCC 15.2.1 and source fortification enabled.

Steps to reproduce:

```
./configure
make amalgamated
gcc -I include -O2 -Wall -Werror -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -o /tmp/bcd-amalgamated.o -c src/bcd-amalgamated.c
```

Observed output:

```
In function ‘bcd_config_assign’,
    inlined from ‘bcd_init’ at src/bcd-amalgamated.c:2608:9:
src/bcd-amalgamated.c:3076:23: error: ‘*(const struct bcd_config *)((char *)&default_config + offsetof(bcd_config_latest_version_t, version)).version’ may be used uninitialized [-Werror=maybe-uninitialized]
 3076 |         switch (bcd_cf->version) {
      |                 ~~~~~~^~~~~~~~~
src/bcd-amalgamated.c: In function ‘bcd_init’:
src/bcd-amalgamated.c:2600:45: note: ‘default_config’ declared here
 2600 |                 bcd_config_latest_version_t default_config;
      |                                             ^~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

This change adds zero initialization of the `default_config` variable in `bcd_init` to suppress the warning.

I don't think this is any real issue but the change is harmless and eliminates the warning.